### PR TITLE
Fix out of order packets

### DIFF
--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/BedrockSession.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/BedrockSession.java
@@ -146,7 +146,7 @@ public abstract class BedrockSession implements MinecraftSession<BedrockPacket> 
         }
     }
 
-    void onTick() {
+    synchronized void onTick() {
         if (this.closed) {
             return;
         }


### PR DESCRIPTION
This forces ticks to be synchronized which means if a particular packet takes too long to compress and encrypt it will still be sent before the next packet.

Closes https://github.com/GeyserMC/Geyser/pull/714