### PR TITLE
Adds missing semicolon to Pong

### DIFF
--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/BedrockPong.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/BedrockPong.java
@@ -93,7 +93,7 @@ public class BedrockPong {
     }
 
     byte[] toRakNet() {
-        StringJoiner joiner = new StringJoiner(";")
+        StringJoiner joiner = new StringJoiner(";", "", ";")
                 .add(this.edition)
                 .add(toString(this.motd))
                 .add(Integer.toString(this.protocolVersion))


### PR DESCRIPTION
Adds a missing semicolon to Pong.

Compare these:

BDS Pong:
`MCPE;Dedicated Server;407;1.16.1;0;10;9320212127489529623;Bedrock level;Survival;1;19130;19131;`

ProxyPass Pong before fix:
`MCPE;ProxyPass;407;0.0.0;0;20;-2326465236099870380;https://github.com/NukkitX/ProxyPass;Survival;1;-1;-1`

ProxyPass Pong after fix:
`MCPE;ProxyPass;407;0.0.0;0;20;-2326465236099870380;https://github.com/NukkitX/ProxyPass;Survival;1;-1;-1;`