### PR TITLE
Add support for Float in MovementDeltaPacket

### DIFF
--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/packet/MoveEntityDeltaPacket.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/packet/MoveEntityDeltaPacket.java
@@ -12,7 +12,10 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(doNotUseGetters = true, callSuper = false)
 public class MoveEntityDeltaPacket extends BedrockPacket {
     private long runtimeEntityId;
-    private Vector3i movementDelta;
+
+    private Vector3i movementDeltaI;
+    private Vector3f movementDeltaF;
+
     private Vector3f rotationDelta;
 
     @Override
@@ -23,4 +26,18 @@ public class MoveEntityDeltaPacket extends BedrockPacket {
     public BedrockPacketType getPacketType() {
         return BedrockPacketType.MOVE_ENTITY_DELTA;
     }
+
+    @Deprecated
+    public Vector3i getMovementDelta() {
+        return movementDeltaI != null ? movementDeltaI : Vector3i.from(movementDeltaF.getX(), movementDeltaF.getY(), movementDeltaF.getZ());
+    }
+
+    public void setMovementDelta(Vector3i movementDelta) {
+        movementDeltaI = movementDelta;
+    }
+
+    public void setMovementDelta(Vector3f movementDelta) {
+        movementDeltaF = movementDelta;
+    }
+
 }


### PR DESCRIPTION
As the new protocol uses both ints and floats this preserves both cases and should be backwards compatible.