### PR TITLE
Add a method to define if an item has blocktime added

### DIFF
--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/BedrockPacketHelper.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/BedrockPacketHelper.java
@@ -606,4 +606,16 @@ public abstract class BedrockPacketHelper {
             buf.writeByte(constraint.ordinal());
         });
     }
+
+    /**
+     * Return true if the item id has a blockingticks attached.
+     *
+     * Only a shield should return true
+     *
+     * @param id ID of item
+     * @return true if reading/writing blockingticks
+     */
+    public boolean isBlockingItem(int id) {
+        return false;
+    }
 }

--- a/bedrock/bedrock-v340/src/main/java/com/nukkitx/protocol/bedrock/v340/BedrockPacketHelper_v340.java
+++ b/bedrock/bedrock-v340/src/main/java/com/nukkitx/protocol/bedrock/v340/BedrockPacketHelper_v340.java
@@ -116,7 +116,7 @@ public class BedrockPacketHelper_v340 extends BedrockPacketHelper_v332 {
         String[] canBreak = readArray(buffer, new String[0], this::readString);
 
         long blockingTicks = 0;
-        if (id == 513) { // We shouldn't be hardcoding this but it's what Microjang have made us do
+        if (isBlockingItem(id)) {
             blockingTicks = VarInts.readLong(buffer);
         }
         return ItemData.of(id, damage, count, compoundTag, canPlace, canBreak, blockingTicks);
@@ -126,7 +126,7 @@ public class BedrockPacketHelper_v340 extends BedrockPacketHelper_v332 {
     public void writeItem(ByteBuf buffer, ItemData item) {
         super.writeItem(buffer, item);
 
-        if (item.getId() == 513) { // TODO: 20/03/2019 We shouldn't be hardcoding this but it's what Microjang have made us do
+        if (isBlockingItem(item.getId())) {
             VarInts.writeLong(buffer, item.getBlockingTicks());
         }
     }
@@ -134,5 +134,10 @@ public class BedrockPacketHelper_v340 extends BedrockPacketHelper_v332 {
     @Override
     public StructureSettings readStructureSettings(ByteBuf buffer) {
         return super.readStructureSettings(buffer);
+    }
+
+    @Override
+    public boolean isBlockingItem(int id) {
+        return id == 513;
     }
 }


### PR DESCRIPTION
This just allows a helper to set if an item has blocking time.

Interestingly I think one can redefine this in StartGamePacket ItemEntries so in theory it may be possible to map this value to a specific ID.