### PR TITLE
Fix canPlace / canBreak encoding and decoding

### DIFF
--- a/bedrock/bedrock-v332/src/main/java/com/nukkitx/protocol/bedrock/v332/BedrockPacketHelper_v332.java
+++ b/bedrock/bedrock-v332/src/main/java/com/nukkitx/protocol/bedrock/v332/BedrockPacketHelper_v332.java
@@ -94,8 +94,17 @@ public class BedrockPacketHelper_v332 extends BedrockPacketHelper_v313 {
                 throw new IllegalStateException("Unable to load NBT data", e);
             }
         }
-        String[] canPlace = readArray(buffer, new String[0], this::readString);
-        String[] canBreak = readArray(buffer, new String[0], this::readString);
+
+        String[] canPlace = new String[VarInts.readInt(buffer)];
+        for (int i = 0; i < canPlace.length; i++) {
+            canPlace[i] = this.readString(buffer);
+        }
+
+        String[] canBreak = new String[VarInts.readInt(buffer)];
+        for (int i = 0; i < canBreak.length; i++) {
+            canBreak[i] = this.readString(buffer);
+        }
+
 
         return ItemData.of(id, damage, count, compoundTag, canPlace, canBreak);
     }
@@ -123,7 +132,17 @@ public class BedrockPacketHelper_v332 extends BedrockPacketHelper_v313 {
         } else {
             buffer.writeShortLE(0);
         }
-        writeArray(buffer, item.getCanPlace(), this::writeString);
-        writeArray(buffer, item.getCanBreak(), this::writeString);
+
+        String[] canPlace = item.getCanPlace();
+        VarInts.writeInt(buffer, canPlace.length);
+        for (String aCanPlace : canPlace) {
+            this.writeString(buffer, aCanPlace);
+        }
+
+        String[] canBreak = item.getCanBreak();
+        VarInts.writeInt(buffer, canBreak.length);
+        for (String aCanBreak : canBreak) {
+            this.writeString(buffer, aCanBreak);
+        }
     }
 }

--- a/bedrock/bedrock-v340/src/main/java/com/nukkitx/protocol/bedrock/v340/BedrockPacketHelper_v340.java
+++ b/bedrock/bedrock-v340/src/main/java/com/nukkitx/protocol/bedrock/v340/BedrockPacketHelper_v340.java
@@ -112,8 +112,16 @@ public class BedrockPacketHelper_v340 extends BedrockPacketHelper_v332 {
                 throw new IllegalStateException("Unable to load NBT data", e);
             }
         }
-        String[] canPlace = readArray(buffer, new String[0], this::readString);
-        String[] canBreak = readArray(buffer, new String[0], this::readString);
+
+        String[] canPlace = new String[VarInts.readInt(buffer)];
+        for (int i = 0; i < canPlace.length; i++) {
+            canPlace[i] = this.readString(buffer);
+        }
+
+        String[] canBreak = new String[VarInts.readInt(buffer)];
+        for (int i = 0; i < canBreak.length; i++) {
+            canBreak[i] = this.readString(buffer);
+        }
 
         long blockingTicks = 0;
         if (id == 513) { // We shouldn't be hardcoding this but it's what Microjang have made us do


### PR DESCRIPTION
Unlike normal arrays, the canPlace and canBreak arrays use normal ints instead of unsigned ints.