### PR TITLE
Have BedrockPacketHelper_v390 extend from v389

### DIFF
--- a/bedrock/bedrock-v390/src/main/java/com/nukkitx/protocol/bedrock/v390/BedrockPacketHelper_v390.java
+++ b/bedrock/bedrock-v390/src/main/java/com/nukkitx/protocol/bedrock/v390/BedrockPacketHelper_v390.java
@@ -1,7 +1,6 @@
 package com.nukkitx.protocol.bedrock.v390;
 
 import com.nukkitx.protocol.bedrock.data.skin.*;
-import com.nukkitx.protocol.bedrock.v388.BedrockPacketHelper_v388;
 import com.nukkitx.protocol.bedrock.v389.BedrockPacketHelper_v389;
 import io.netty.buffer.ByteBuf;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;

--- a/bedrock/bedrock-v390/src/main/java/com/nukkitx/protocol/bedrock/v390/BedrockPacketHelper_v390.java
+++ b/bedrock/bedrock-v390/src/main/java/com/nukkitx/protocol/bedrock/v390/BedrockPacketHelper_v390.java
@@ -2,6 +2,7 @@ package com.nukkitx.protocol.bedrock.v390;
 
 import com.nukkitx.protocol.bedrock.data.skin.*;
 import com.nukkitx.protocol.bedrock.v388.BedrockPacketHelper_v388;
+import com.nukkitx.protocol.bedrock.v389.BedrockPacketHelper_v389;
 import io.netty.buffer.ByteBuf;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import lombok.AccessLevel;
@@ -12,7 +13,7 @@ import java.util.List;
 import static java.util.Objects.requireNonNull;
 
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-public class BedrockPacketHelper_v390 extends BedrockPacketHelper_v388 {
+public class BedrockPacketHelper_v390 extends BedrockPacketHelper_v389 {
     public static final BedrockPacketHelper_v390 INSTANCE = new BedrockPacketHelper_v390();
 
     @Override


### PR DESCRIPTION
Fixes particles not being mapped correctly.