### PR TITLE
Upgrade Nimbus JOSE + JWT to v5.2

### DIFF
--- a/bedrock/bedrock-common/pom.xml
+++ b/bedrock/bedrock-common/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
-            <version>4.41.2</version>
+            <version>5.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/util/EncryptionUtils.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/util/EncryptionUtils.java
@@ -6,7 +6,7 @@ import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSObject;
 import com.nimbusds.jose.crypto.ECDSASigner;
 import com.nimbusds.jose.crypto.ECDSAVerifier;
-import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nukkitx.natives.aes.AesFactory;
@@ -91,7 +91,7 @@ public class EncryptionUtils {
      * @throws JOSEException invalid key provided
      */
     public static void signJwt(JWSObject jws, ECPrivateKey key) throws JOSEException {
-        jws.sign(new ECDSASigner(key, ECKey.Curve.P_384));
+        jws.sign(new ECDSASigner(key, Curve.P_384));
     }
 
     /**


### PR DESCRIPTION
This is for compatibility with Geyser + Waterdog, which has an incompatibility due differences in method signatures.