### PR TITLE
Item improvements & ViolationPacket naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ server.bind().join();
         <dependency>
             <groupId>com.nukkitx.protocol</groupId>
             <artifactId>bedrock-v(VERSION)</artifactId>
-            <version>2.6.0-SNAPSHOT</version>
+            <version>2.6.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/bedrock/bedrock-common/pom.xml
+++ b/bedrock/bedrock-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bedrock-parent</artifactId>
         <groupId>com.nukkitx.protocol</groupId>
-        <version>2.6.0-SNAPSHOT</version>
+        <version>2.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/BedrockSession.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/BedrockSession.java
@@ -30,6 +30,7 @@ import java.net.InetSocketAddress;
 import java.security.GeneralSecurityException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.zip.Deflater;
@@ -55,7 +56,7 @@ public abstract class BedrockSession implements MinecraftSession<BedrockPacket> 
     private volatile boolean closed = false;
     private volatile boolean logging = true;
 
-    private int hardcodedBlockingId = -1;
+    private AtomicInteger hardcodedBlockingId = new AtomicInteger(-1);
 
     static {
         // Required for Android API versions prior to 26.
@@ -340,11 +341,7 @@ public abstract class BedrockSession implements MinecraftSession<BedrockPacket> 
         this.disconnectHandlers.add(disconnectHandler);
     }
 
-    public void setHardcodedBlockingId(int hardcodedBlockingId) {
-        this.hardcodedBlockingId = hardcodedBlockingId;
-    }
-
-    public int getHardcodedBlockingId() {
+    public AtomicInteger getHardcodedBlockingId() {
         return this.hardcodedBlockingId;
     }
 

--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/data/inventory/CraftingData.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/data/inventory/CraftingData.java
@@ -1,8 +1,11 @@
 package com.nukkitx.protocol.bedrock.data.inventory;
 
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 @Value
@@ -14,8 +17,8 @@ public class CraftingData {
     private final int height;
     private final int inputId;
     private final int inputDamage;
-    private final ItemData[] inputs;
-    private final ItemData[] outputs;
+    private final List<ItemData> inputs;
+    private final List<ItemData> outputs;
     private final UUID uuid;
     private final String craftingTag;
     private final int priority;
@@ -23,99 +26,99 @@ public class CraftingData {
 
     // @Todo changed networkId to id to match rest of code
 
-    public CraftingData(CraftingDataType type, String recipeId, int width, int height, int inputId, int inputDamage, ItemData[] inputs,
-                        ItemData[] outputs, UUID uuid, String craftingTag, int priority) {
+    public CraftingData(CraftingDataType type, String recipeId, int width, int height, int inputId, int inputDamage, List<ItemData> inputs,
+                        List<ItemData> outputs, UUID uuid, String craftingTag, int priority) {
         this(type, recipeId, width, height, inputId, inputDamage, inputs, outputs, uuid, craftingTag, priority, -1);
     }
 
-    public CraftingData(CraftingDataType type, int width, int height, int inputId, int inputDamage, ItemData[] inputs,
-                        ItemData[] outputs, UUID uuid, String craftingTag, int networkId) {
+    public CraftingData(CraftingDataType type, int width, int height, int inputId, int inputDamage, List<ItemData> inputs,
+                        List<ItemData> outputs, UUID uuid, String craftingTag, int networkId) {
         this(type, null, width, height, inputId, inputDamage, inputs, outputs, uuid, craftingTag, 0, networkId);
     }
 
-    public CraftingData(CraftingDataType type, int width, int height, int inputId, int inputDamage, ItemData[] inputs,
-                        ItemData[] outputs, UUID uuid, String craftingTag) {
+    public CraftingData(CraftingDataType type, int width, int height, int inputId, int inputDamage, List<ItemData> inputs,
+                        List<ItemData> outputs, UUID uuid, String craftingTag) {
         this(type, null, width, height, inputId, inputDamage, inputs, outputs, uuid, craftingTag, 0, -1);
     }
 
     public static CraftingData fromFurnaceData(int inputId, int inputDamage, ItemData output, String craftingTag,
                                                int networkId) {
         return new CraftingData(CraftingDataType.FURNACE_DATA, null, -1, -1, inputId, inputDamage,
-                null, new ItemData[]{output}, null, craftingTag, -1, networkId);
+                null, new ObjectArrayList<>(Collections.singleton(output)), null, craftingTag, -1, networkId);
     }
 
     public static CraftingData fromFurnaceData(int inputId, int inputDamage, ItemData output, String craftingTag) {
         return new CraftingData(CraftingDataType.FURNACE_DATA, null, -1, -1, inputId, inputDamage,
-                null, new ItemData[]{output}, null, craftingTag, -1, -1);
+                null, new ObjectArrayList<>(Collections.singleton(output)), null, craftingTag, -1, -1);
     }
 
     public static CraftingData fromFurnace(int inputId, ItemData input, String craftingTag, int networkId) {
         return new CraftingData(CraftingDataType.FURNACE, null, -1, -1, inputId, -1,
-                null, new ItemData[]{input}, null, craftingTag, -1, networkId);
+                null, new ObjectArrayList<>(Collections.singleton(input)), null, craftingTag, -1, networkId);
     }
 
     public static CraftingData fromFurnace(int inputId, ItemData input, String craftingTag) {
         return new CraftingData(CraftingDataType.FURNACE, null, -1, -1, inputId, -1,
-                null, new ItemData[]{input}, null, craftingTag, -1, -1);
+                null, new ObjectArrayList<>(Collections.singleton(input)), null, craftingTag, -1, -1);
     }
 
-    public static CraftingData fromShapeless(String recipeId, ItemData[] inputs, ItemData[] outputs, UUID uuid,
+    public static CraftingData fromShapeless(String recipeId, List<ItemData> inputs, List<ItemData> outputs, UUID uuid,
                                              String craftingTag, int priority, int networkId) {
         return new CraftingData(CraftingDataType.SHAPELESS, recipeId, -1, -1, -1, -1,
                 inputs, outputs, uuid, craftingTag, priority, networkId);
     }
 
-    public static CraftingData fromShapeless(String recipeId, ItemData[] inputs, ItemData[] outputs, UUID uuid,
+    public static CraftingData fromShapeless(String recipeId, List<ItemData> inputs, List<ItemData> outputs, UUID uuid,
                                              String craftingTag, int priority) {
         return new CraftingData(CraftingDataType.SHAPELESS, recipeId, -1, -1, -1, -1,
                 inputs, outputs, uuid, craftingTag, priority, -1);
     }
 
-    public static CraftingData fromShaped(String recipeId, int width, int height, ItemData[] inputs,
-                                          ItemData[] outputs, UUID uuid, String craftingTag, int priority,
+    public static CraftingData fromShaped(String recipeId, int width, int height, List<ItemData> inputs,
+                                          List<ItemData> outputs, UUID uuid, String craftingTag, int priority,
                                           int networkId) {
         return new CraftingData(CraftingDataType.SHAPED, recipeId, width, height, -1, -1, inputs,
                 outputs, uuid, craftingTag, priority, networkId);
     }
 
-    public static CraftingData fromShaped(String recipeId, int width, int height, ItemData[] inputs,
-                                          ItemData[] outputs, UUID uuid, String craftingTag, int priority) {
+    public static CraftingData fromShaped(String recipeId, int width, int height, List<ItemData> inputs,
+                                          List<ItemData> outputs, UUID uuid, String craftingTag, int priority) {
         return new CraftingData(CraftingDataType.SHAPED, recipeId, width, height, -1, -1, inputs,
                 outputs, uuid, craftingTag, priority, -1);
     }
 
-    public static CraftingData fromShapelessChemistry(String recipeId, ItemData[] inputs, ItemData[] outputs,
+    public static CraftingData fromShapelessChemistry(String recipeId, List<ItemData> inputs, List<ItemData> outputs,
                                                       UUID uuid, String craftingTag, int priority, int networkId) {
         return new CraftingData(CraftingDataType.SHAPELESS_CHEMISTRY, recipeId, -1, -1, -1,
                 -1, inputs, outputs, uuid, craftingTag, priority, networkId);
     }
 
-    public static CraftingData fromShapelessChemistry(String recipeId, ItemData[] inputs, ItemData[] outputs,
+    public static CraftingData fromShapelessChemistry(String recipeId, List<ItemData> inputs, List<ItemData> outputs,
                                                       UUID uuid, String craftingTag, int priority) {
         return new CraftingData(CraftingDataType.SHAPELESS_CHEMISTRY, recipeId, -1, -1, -1,
                 -1, inputs, outputs, uuid, craftingTag, priority, -1);
     }
 
-    public static CraftingData fromShapedChemistry(String recipeId, int width, int height, ItemData[] inputs,
-                                                   ItemData[] outputs, UUID uuid, String craftingTag, int priority,
+    public static CraftingData fromShapedChemistry(String recipeId, int width, int height, List<ItemData> inputs,
+                                                   List<ItemData> outputs, UUID uuid, String craftingTag, int priority,
                                                    int networkId) {
         return new CraftingData(CraftingDataType.SHAPED_CHEMISTRY, recipeId, width, height, -1, -1,
                 inputs, outputs, uuid, craftingTag, priority, networkId);
     }
 
-    public static CraftingData fromShapedChemistry(String recipeId, int width, int height, ItemData[] inputs,
-                                                   ItemData[] outputs, UUID uuid, String craftingTag, int priority) {
+    public static CraftingData fromShapedChemistry(String recipeId, int width, int height, List<ItemData> inputs,
+                                                   List<ItemData> outputs, UUID uuid, String craftingTag, int priority) {
         return new CraftingData(CraftingDataType.SHAPED_CHEMISTRY, recipeId, width, height, -1, -1,
                 inputs, outputs, uuid, craftingTag, priority, -1);
     }
 
-    public static CraftingData fromShulkerBox(String recipeId, ItemData[] inputs, ItemData[] outputs, UUID uuid,
+    public static CraftingData fromShulkerBox(String recipeId, List<ItemData> inputs, List<ItemData> outputs, UUID uuid,
                                               String craftingTag, int priority, int networkId) {
         return new CraftingData(CraftingDataType.SHULKER_BOX, recipeId, -1, -1, -1, -1,
                 inputs, outputs, uuid, craftingTag, priority, networkId);
     }
 
-    public static CraftingData fromShulkerBox(String recipeId, ItemData[] inputs, ItemData[] outputs, UUID uuid,
+    public static CraftingData fromShulkerBox(String recipeId, List<ItemData> inputs, List<ItemData> outputs, UUID uuid,
                                               String craftingTag, int priority) {
         return new CraftingData(CraftingDataType.SHULKER_BOX, recipeId, -1, -1, -1, -1,
                 inputs, outputs, uuid, craftingTag, priority, -1);
@@ -131,60 +134,60 @@ public class CraftingData {
                 null, null, uuid, null, -1, -1);
     }
 
-    public static CraftingData fromShapeless(ItemData[] inputs, ItemData[] outputs, UUID uuid, String craftingTag,
+    public static CraftingData fromShapeless(List<ItemData> inputs, List<ItemData> outputs, UUID uuid, String craftingTag,
                                              int networkId) {
         return new CraftingData(CraftingDataType.SHAPELESS, "", -1, -1, -1, -1, inputs, outputs,
                 uuid, craftingTag, 0, networkId);
     }
 
-    public static CraftingData fromShapeless(ItemData[] inputs, ItemData[] outputs, UUID uuid, String craftingTag) {
+    public static CraftingData fromShapeless(List<ItemData> inputs, List<ItemData> outputs, UUID uuid, String craftingTag) {
         return new CraftingData(CraftingDataType.SHAPELESS, "", -1, -1, -1, -1, inputs, outputs,
                 uuid, craftingTag, 0, -1);
     }
 
-    public static CraftingData fromShaped(int width, int height, ItemData[] inputs, ItemData[] outputs, UUID uuid,
+    public static CraftingData fromShaped(int width, int height, List<ItemData> inputs, List<ItemData> outputs, UUID uuid,
                                           String craftingTag, int networkId) {
         return new CraftingData(CraftingDataType.SHAPED, "", width, height, -1, -1, inputs, outputs, uuid,
                 craftingTag, 0, networkId);
     }
 
-    public static CraftingData fromShaped(int width, int height, ItemData[] inputs, ItemData[] outputs, UUID uuid,
+    public static CraftingData fromShaped(int width, int height, List<ItemData> inputs, List<ItemData> outputs, UUID uuid,
                                           String craftingTag) {
         return new CraftingData(CraftingDataType.SHAPED, "", width, height, -1, -1, inputs, outputs, uuid,
                 craftingTag, 0, -1);
     }
 
-    public static CraftingData fromShapelessChemistry(ItemData[] inputs, ItemData[] outputs, UUID uuid,
+    public static CraftingData fromShapelessChemistry(List<ItemData> inputs, List<ItemData> outputs, UUID uuid,
                                                       String craftingTag, int networkId) {
         return new CraftingData(CraftingDataType.SHAPELESS_CHEMISTRY, "", -1, -1, -1, -1,
                 inputs, outputs, uuid, craftingTag, 0, networkId);
     }
 
-    public static CraftingData fromShapelessChemistry(ItemData[] inputs, ItemData[] outputs, UUID uuid,
+    public static CraftingData fromShapelessChemistry(List<ItemData> inputs, List<ItemData> outputs, UUID uuid,
                                                       String craftingTag) {
         return new CraftingData(CraftingDataType.SHAPELESS_CHEMISTRY, "", -1, -1, -1, -1,
                 inputs, outputs, uuid, craftingTag, 0, -1);
     }
 
-    public static CraftingData fromShapedChemistry(int width, int height, ItemData[] inputs, ItemData[] outputs,
+    public static CraftingData fromShapedChemistry(int width, int height, List<ItemData> inputs, List<ItemData> outputs,
                                                    UUID uuid, String craftingTag, int networkId) {
         return new CraftingData(CraftingDataType.SHAPED_CHEMISTRY, "", width, height, -1, -1, inputs,
                 outputs, uuid, craftingTag, 0, networkId);
     }
 
-    public static CraftingData fromShapedChemistry(int width, int height, ItemData[] inputs, ItemData[] outputs,
+    public static CraftingData fromShapedChemistry(int width, int height, List<ItemData> inputs, List<ItemData> outputs,
                                                    UUID uuid, String craftingTag) {
         return new CraftingData(CraftingDataType.SHAPED_CHEMISTRY, "", width, height, -1, -1, inputs,
                 outputs, uuid, craftingTag, 0, -1);
     }
 
-    public static CraftingData fromShulkerBox(ItemData[] inputs, ItemData[] outputs, UUID uuid, String craftingTag,
+    public static CraftingData fromShulkerBox(List<ItemData> inputs, List<ItemData> outputs, UUID uuid, String craftingTag,
                                               int networkId) {
         return new CraftingData(CraftingDataType.SHULKER_BOX, "", -1, -1, -1, -1, inputs, outputs,
                 uuid, craftingTag, 0, networkId);
     }
 
-    public static CraftingData fromShulkerBox(ItemData[] inputs, ItemData[] outputs, UUID uuid, String craftingTag) {
+    public static CraftingData fromShulkerBox(List<ItemData> inputs, List<ItemData> outputs, UUID uuid, String craftingTag) {
         return new CraftingData(CraftingDataType.SHULKER_BOX, "", -1, -1, -1, -1, inputs, outputs,
                 uuid, craftingTag, 0, -1);
     }

--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/data/inventory/ItemData.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/data/inventory/ItemData.java
@@ -4,6 +4,7 @@ import com.nukkitx.nbt.NbtMap;
 import com.nukkitx.network.util.Preconditions;
 import lombok.AccessLevel;
 import lombok.Data;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.NonFinal;
 
@@ -18,7 +19,9 @@ public final class ItemData {
     private static final String[] EMPTY = new String[0];
     public static final ItemData AIR = new ItemData(0, (short) 0, 0, null, EMPTY, EMPTY, 0);
 
-    private final int id;
+    @NonNull
+    @NonFinal
+    private int id;
     private final short damage;
     private final int count;
     private final NbtMap tag;

--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/packet/InventoryContentPacket.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/packet/InventoryContentPacket.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Data
 @EqualsAndHashCode(doNotUseGetters = true, callSuper = false)
 public class InventoryContentPacket extends BedrockPacket {
-    private List<ItemData> contents = new ObjectArrayList<>();;
+    private List<ItemData> contents = new ObjectArrayList<>();
     private int containerId;
 
     @Override

--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/packet/InventoryContentPacket.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/packet/InventoryContentPacket.java
@@ -4,13 +4,16 @@ import com.nukkitx.protocol.bedrock.BedrockPacket;
 import com.nukkitx.protocol.bedrock.BedrockPacketType;
 import com.nukkitx.protocol.bedrock.data.inventory.ItemData;
 import com.nukkitx.protocol.bedrock.handler.BedrockPacketHandler;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+
+import java.util.List;
 
 @Data
 @EqualsAndHashCode(doNotUseGetters = true, callSuper = false)
 public class InventoryContentPacket extends BedrockPacket {
-    private ItemData[] contents;
+    private List<ItemData> contents = new ObjectArrayList<>();;
     private int containerId;
 
     @Override

--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/packet/PacketViolationWarningPacket.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/packet/PacketViolationWarningPacket.java
@@ -13,7 +13,7 @@ import lombok.EqualsAndHashCode;
 public class PacketViolationWarningPacket extends BedrockPacket {
     private PacketViolationType type;
     private PacketViolationSeverity severity;
-    private int packetId;
+    private int packetCauseId;
     private String context;
 
     @Override

--- a/bedrock/bedrock-v291/pom.xml
+++ b/bedrock/bedrock-v291/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bedrock-parent</artifactId>
         <groupId>com.nukkitx.protocol</groupId>
-        <version>2.6.0-SNAPSHOT</version>
+        <version>2.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bedrock/bedrock-v291/src/main/java/com/nukkitx/protocol/bedrock/v291/serializer/InventoryContentSerializer_v291.java
+++ b/bedrock/bedrock-v291/src/main/java/com/nukkitx/protocol/bedrock/v291/serializer/InventoryContentSerializer_v291.java
@@ -14,8 +14,6 @@ import lombok.NoArgsConstructor;
 public class InventoryContentSerializer_v291 implements BedrockPacketSerializer<InventoryContentPacket> {
     public static final InventoryContentSerializer_v291 INSTANCE = new InventoryContentSerializer_v291();
 
-    private static final ItemData[] EMPTY = new ItemData[0];
-
     @Override
     public void serialize(ByteBuf buffer, BedrockPacketHelper helper, InventoryContentPacket packet, BedrockSession session) {
         VarInts.writeUnsignedInt(buffer, packet.getContainerId());
@@ -25,6 +23,6 @@ public class InventoryContentSerializer_v291 implements BedrockPacketSerializer<
     @Override
     public void deserialize(ByteBuf buffer, BedrockPacketHelper helper, InventoryContentPacket packet, BedrockSession session) {
         packet.setContainerId(VarInts.readUnsignedInt(buffer));
-        packet.setContents(helper.readArray(buffer, EMPTY, buf -> helper.readItem(buf, session)));
+        helper.readArray(buffer, packet.getContents(), buf -> helper.readItem(buf, session));
     }
 }

--- a/bedrock/bedrock-v313/pom.xml
+++ b/bedrock/bedrock-v313/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bedrock-parent</artifactId>
         <groupId>com.nukkitx.protocol</groupId>
-        <version>2.6.0-SNAPSHOT</version>
+        <version>2.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bedrock/bedrock-v332/pom.xml
+++ b/bedrock/bedrock-v332/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bedrock-parent</artifactId>
         <groupId>com.nukkitx.protocol</groupId>
-        <version>2.6.0-SNAPSHOT</version>
+        <version>2.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bedrock/bedrock-v340/pom.xml
+++ b/bedrock/bedrock-v340/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bedrock-parent</artifactId>
         <groupId>com.nukkitx.protocol</groupId>
-        <version>2.6.0-SNAPSHOT</version>
+        <version>2.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bedrock/bedrock-v340/src/main/java/com/nukkitx/protocol/bedrock/v340/BedrockPacketHelper_v340.java
+++ b/bedrock/bedrock-v340/src/main/java/com/nukkitx/protocol/bedrock/v340/BedrockPacketHelper_v340.java
@@ -120,7 +120,7 @@ public class BedrockPacketHelper_v340 extends BedrockPacketHelper_v332 {
         }
 
         long blockingTicks = 0;
-        if (this.isBlockingItem(id, session.getHardcodedBlockingId())) {
+        if (this.isBlockingItem(id, session.getHardcodedBlockingId().get())) {
             blockingTicks = VarInts.readLong(buffer);
         }
         return ItemData.of(id, damage, count, compoundTag, canPlace, canBreak, blockingTicks);
@@ -130,7 +130,7 @@ public class BedrockPacketHelper_v340 extends BedrockPacketHelper_v332 {
     public void writeItem(ByteBuf buffer, ItemData item, BedrockSession session) {
         super.writeItem(buffer, item, session);
 
-        if (this.isBlockingItem(item.getId(), session.getHardcodedBlockingId())) {
+        if (this.isBlockingItem(item.getId(), session.getHardcodedBlockingId().get())) {
             VarInts.writeLong(buffer, item.getBlockingTicks());
         }
     }

--- a/bedrock/bedrock-v354/pom.xml
+++ b/bedrock/bedrock-v354/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bedrock-parent</artifactId>
         <groupId>com.nukkitx.protocol</groupId>
-        <version>2.6.0-SNAPSHOT</version>
+        <version>2.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bedrock/bedrock-v354/src/main/java/com/nukkitx/protocol/bedrock/v354/serializer/CraftingDataSerializer_v354.java
+++ b/bedrock/bedrock-v354/src/main/java/com/nukkitx/protocol/bedrock/v354/serializer/CraftingDataSerializer_v354.java
@@ -8,9 +8,12 @@ import com.nukkitx.protocol.bedrock.data.inventory.CraftingDataType;
 import com.nukkitx.protocol.bedrock.data.inventory.ItemData;
 import com.nukkitx.protocol.bedrock.v291.serializer.CraftingDataSerializer_v291;
 import io.netty.buffer.ByteBuf;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -19,12 +22,15 @@ public class CraftingDataSerializer_v354 extends CraftingDataSerializer_v291 {
 
     @Override
     protected CraftingData readShapelessRecipe(ByteBuf buffer, BedrockPacketHelper helper, CraftingDataType type, BedrockSession session) {
-        ItemData[] inputs = helper.readArray(buffer, EMPTY_ARRAY, buf -> helper.readItem(buf, session));
-        ItemData[] outputs = helper.readArray(buffer, EMPTY_ARRAY, buf -> helper.readItem(buf, session));
+        List<ItemData> inputs = new ObjectArrayList<>();
+        helper.readArray(buffer, inputs, buf -> helper.readItem(buf, session));
+
+        List<ItemData> outputs = new ObjectArrayList<>();
+        helper.readArray(buffer, outputs, buf -> helper.readItem(buf, session));
+
         UUID uuid = helper.readUuid(buffer);
         String craftingTag = helper.readString(buffer);
-        return new CraftingData(type, -1, -1, -1, -1, inputs, outputs, uuid,
-                craftingTag);
+        return new CraftingData(type, -1, -1, -1, -1, inputs, outputs, uuid, craftingTag);
     }
 
     @Override
@@ -39,15 +45,15 @@ public class CraftingDataSerializer_v354 extends CraftingDataSerializer_v291 {
         int width = VarInts.readInt(buffer);
         int height = VarInts.readInt(buffer);
         int inputCount = width * height;
-        ItemData[] inputs = new ItemData[inputCount];
+        List<ItemData> inputs = new ObjectArrayList<>(inputCount);
         for (int i = 0; i < inputCount; i++) {
-            inputs[i] = helper.readItem(buffer, session);
+            inputs.add(helper.readItem(buffer, session));
         }
-        ItemData[] outputs = helper.readArray(buffer, EMPTY_ARRAY, buf -> helper.readItem(buf, session));
+        List<ItemData> outputs = new ObjectArrayList<>();
+        helper.readArray(buffer, outputs, buf -> helper.readItem(buf, session));
         UUID uuid = helper.readUuid(buffer);
         String craftingTag = helper.readString(buffer);
-        return new CraftingData(type, width, height, -1, -1, inputs, outputs, uuid,
-                craftingTag);
+        return new CraftingData(type, width, height, -1, -1, inputs, outputs, uuid, craftingTag);
     }
 
     @Override
@@ -61,10 +67,9 @@ public class CraftingDataSerializer_v354 extends CraftingDataSerializer_v291 {
     protected CraftingData readFurnaceRecipe(ByteBuf buffer, BedrockPacketHelper helper, CraftingDataType type, BedrockSession session) {
         int inputId = VarInts.readInt(buffer);
         int inputDamage = type == CraftingDataType.FURNACE_DATA ? VarInts.readInt(buffer) : -1;
-        ItemData[] output = new ItemData[]{helper.readItem(buffer, session)};
+        List<ItemData> output = new ObjectArrayList<>(Collections.singleton(helper.readItem(buffer, session)));
         String craftingTag = helper.readString(buffer);
-        return new CraftingData(type, -1, -1, inputId, inputDamage, null, output, null,
-                craftingTag);
+        return new CraftingData(type, -1, -1, inputId, inputDamage, null, output, null, craftingTag);
     }
 
     @Override

--- a/bedrock/bedrock-v361/pom.xml
+++ b/bedrock/bedrock-v361/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bedrock-parent</artifactId>
         <groupId>com.nukkitx.protocol</groupId>
-        <version>2.6.0-SNAPSHOT</version>
+        <version>2.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bedrock/bedrock-v361/src/main/java/com/nukkitx/protocol/bedrock/v361/serializer/CraftingDataSerializer_v361.java
+++ b/bedrock/bedrock-v361/src/main/java/com/nukkitx/protocol/bedrock/v361/serializer/CraftingDataSerializer_v361.java
@@ -8,9 +8,11 @@ import com.nukkitx.protocol.bedrock.data.inventory.CraftingDataType;
 import com.nukkitx.protocol.bedrock.data.inventory.ItemData;
 import com.nukkitx.protocol.bedrock.v354.serializer.CraftingDataSerializer_v354;
 import io.netty.buffer.ByteBuf;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
 import java.util.UUID;
 
 import static java.util.Objects.requireNonNull;
@@ -22,8 +24,12 @@ public class CraftingDataSerializer_v361 extends CraftingDataSerializer_v354 {
     @Override
     protected CraftingData readShapelessRecipe(ByteBuf buffer, BedrockPacketHelper helper, CraftingDataType type, BedrockSession session) {
         String recipeId = helper.readString(buffer);
-        ItemData[] inputs = helper.readArray(buffer, EMPTY_ARRAY, this::readIngredient);
-        ItemData[] outputs = helper.readArray(buffer, EMPTY_ARRAY, buf -> helper.readItem(buf, session));
+        List<ItemData> inputs = new ObjectArrayList<>();
+        helper.readArray(buffer, inputs, this::readIngredient);
+
+        List<ItemData> outputs = new ObjectArrayList<>();
+        helper.readArray(buffer, outputs, buf -> helper.readItem(buf, session));
+
         UUID uuid = helper.readUuid(buffer);
         String craftingTag = helper.readString(buffer);
         int priority = VarInts.readInt(buffer);
@@ -47,11 +53,12 @@ public class CraftingDataSerializer_v361 extends CraftingDataSerializer_v354 {
         int width = VarInts.readInt(buffer);
         int height = VarInts.readInt(buffer);
         int inputCount = width * height;
-        ItemData[] inputs = new ItemData[inputCount];
+        List<ItemData> inputs = new ObjectArrayList<>(inputCount);
         for (int i = 0; i < inputCount; i++) {
-            inputs[i] = this.readIngredient(buffer);
+            inputs.add(this.readIngredient(buffer));
         }
-        ItemData[] outputs = helper.readArray(buffer, EMPTY_ARRAY, buf -> helper.readItem(buf, session));
+        List<ItemData> outputs = new ObjectArrayList<>();
+        helper.readArray(buffer, outputs, buf -> helper.readItem(buf, session));
         UUID uuid = helper.readUuid(buffer);
         String craftingTag = helper.readString(buffer);
         int priority = VarInts.readInt(buffer);
@@ -65,9 +72,9 @@ public class CraftingDataSerializer_v361 extends CraftingDataSerializer_v354 {
         VarInts.writeInt(buffer, data.getWidth());
         VarInts.writeInt(buffer, data.getHeight());
         int count = data.getWidth() * data.getHeight();
-        ItemData[] inputs = data.getInputs();
+        List<ItemData> inputs = data.getInputs();
         for (int i = 0; i < count; i++) {
-            this.writeIngredient(buffer, inputs[i]);
+            this.writeIngredient(buffer, inputs.get(i));
         }
         helper.writeArray(buffer, data.getOutputs(), (buf, item) -> helper.writeItem(buf, item, session));
         helper.writeUuid(buffer, data.getUuid());

--- a/bedrock/bedrock-v388/pom.xml
+++ b/bedrock/bedrock-v388/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bedrock-parent</artifactId>
         <groupId>com.nukkitx.protocol</groupId>
-        <version>2.6.0-SNAPSHOT</version>
+        <version>2.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bedrock/bedrock-v389/pom.xml
+++ b/bedrock/bedrock-v389/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bedrock-parent</artifactId>
         <groupId>com.nukkitx.protocol</groupId>
-        <version>2.6.0-SNAPSHOT</version>
+        <version>2.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bedrock/bedrock-v390/pom.xml
+++ b/bedrock/bedrock-v390/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bedrock-parent</artifactId>
         <groupId>com.nukkitx.protocol</groupId>
-        <version>2.6.0-SNAPSHOT</version>
+        <version>2.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bedrock/bedrock-v407/pom.xml
+++ b/bedrock/bedrock-v407/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bedrock-parent</artifactId>
         <groupId>com.nukkitx.protocol</groupId>
-        <version>2.6.0-SNAPSHOT</version>
+        <version>2.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bedrock/bedrock-v407/src/main/java/com/nukkitx/protocol/bedrock/v407/serializer/InventoryContentSerializer_v407.java
+++ b/bedrock/bedrock-v407/src/main/java/com/nukkitx/protocol/bedrock/v407/serializer/InventoryContentSerializer_v407.java
@@ -14,8 +14,6 @@ import lombok.NoArgsConstructor;
 public class InventoryContentSerializer_v407 implements BedrockPacketSerializer<InventoryContentPacket> {
     public static final InventoryContentSerializer_v407 INSTANCE = new InventoryContentSerializer_v407();
 
-    private static final ItemData[] EMPTY = new ItemData[0];
-
     @Override
     public void serialize(ByteBuf buffer, BedrockPacketHelper helper, InventoryContentPacket packet, BedrockSession session) {
         VarInts.writeUnsignedInt(buffer, packet.getContainerId());
@@ -25,6 +23,6 @@ public class InventoryContentSerializer_v407 implements BedrockPacketSerializer<
     @Override
     public void deserialize(ByteBuf buffer, BedrockPacketHelper helper, InventoryContentPacket packet, BedrockSession session) {
         packet.setContainerId(VarInts.readUnsignedInt(buffer));
-        packet.setContents(helper.readArray(buffer, EMPTY, buf -> helper.readNetItem(buf, session)));
+        helper.readArray(buffer, packet.getContents(), buf -> helper.readNetItem(buf, session));
     }
 }

--- a/bedrock/bedrock-v407/src/main/java/com/nukkitx/protocol/bedrock/v407/serializer/PacketViolationWarningSerializer_v407.java
+++ b/bedrock/bedrock-v407/src/main/java/com/nukkitx/protocol/bedrock/v407/serializer/PacketViolationWarningSerializer_v407.java
@@ -21,7 +21,7 @@ public class PacketViolationWarningSerializer_v407 implements BedrockPacketSeria
     public void serialize(ByteBuf buffer, BedrockPacketHelper helper, PacketViolationWarningPacket packet) {
         VarInts.writeInt(buffer, packet.getType().ordinal() - 1);
         VarInts.writeInt(buffer, packet.getSeverity().ordinal());
-        VarInts.writeInt(buffer, packet.getPacketId());
+        VarInts.writeInt(buffer, packet.getPacketCauseId());
         helper.writeString(buffer, packet.getContext());
     }
 
@@ -29,7 +29,7 @@ public class PacketViolationWarningSerializer_v407 implements BedrockPacketSeria
     public void deserialize(ByteBuf buffer, BedrockPacketHelper helper, PacketViolationWarningPacket packet) {
         packet.setType(TYPES[VarInts.readInt(buffer) + 1]);
         packet.setSeverity(SEVERITIES[VarInts.readInt(buffer)]);
-        packet.setPacketId(VarInts.readInt(buffer));
+        packet.setPacketCauseId(VarInts.readInt(buffer));
         packet.setContext(helper.readString(buffer));
     }
 }

--- a/bedrock/bedrock-v408/pom.xml
+++ b/bedrock/bedrock-v408/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bedrock-parent</artifactId>
         <groupId>com.nukkitx.protocol</groupId>
-        <version>2.6.0-SNAPSHOT</version>
+        <version>2.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bedrock/bedrock-v419/pom.xml
+++ b/bedrock/bedrock-v419/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bedrock-parent</artifactId>
         <groupId>com.nukkitx.protocol</groupId>
-        <version>2.6.0-SNAPSHOT</version>
+        <version>2.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bedrock/pom.xml
+++ b/bedrock/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.nukkitx.protocol</groupId>
-        <version>2.6.0-SNAPSHOT</version>
+        <version>2.6.1-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.nukkitx.protocol</groupId>
-        <version>2.6.0-SNAPSHOT</version>
+        <version>2.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.nukkitx.protocol</groupId>
     <artifactId>parent</artifactId>
     <packaging>pom</packaging>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
     <name>Protocol Parent</name>
     <description>A protocol library for Minecraft</description>
     <url>https://github.com/NukkitX/Protocol</url>


### PR DESCRIPTION
- Allow to change content of `ItemData` arrays without creating new array.
- Make id of `ItemData` non-final to allow item id changes.
- Change `packetId` to `packetCauseId` to prevent `BedrockPacket` value overridding.