### PR TITLE
Use retained buffer in UnknownPacket & release packets by default

### DIFF
--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/handler/DefaultBatchHandler.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/handler/DefaultBatchHandler.java
@@ -24,9 +24,17 @@ public class DefaultBatchHandler implements BatchHandler {
             }
 
             BedrockPacketHandler handler = session.getPacketHandler();
-            if (handler == null || !packet.handle(handler)) {
-                log.debug("Unhandled packet for {}: {}", session.getAddress(), packet);
-                ReferenceCountUtil.release(packet);
+            boolean release = true;
+            try {
+                if (handler != null && packet.handle(handler)) {
+                    release = false;
+                } else {
+                    log.debug("Unhandled packet for {}: {}", session.getAddress(), packet);
+                }
+            } finally {
+                if (release) {
+                    ReferenceCountUtil.release(packet);
+                }
             }
         }
     }

--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/handler/DefaultBatchHandler.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/handler/DefaultBatchHandler.java
@@ -3,6 +3,7 @@ package com.nukkitx.protocol.bedrock.handler;
 import com.nukkitx.protocol.bedrock.BedrockPacket;
 import com.nukkitx.protocol.bedrock.BedrockSession;
 import io.netty.buffer.ByteBuf;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import lombok.AccessLevel;
@@ -25,6 +26,7 @@ public class DefaultBatchHandler implements BatchHandler {
             BedrockPacketHandler handler = session.getPacketHandler();
             if (handler == null || !packet.handle(handler)) {
                 log.debug("Unhandled packet for {}: {}", session.getAddress(), packet);
+                ReferenceCountUtil.release(packet);
             }
         }
     }

--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/packet/UnknownPacket.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/packet/UnknownPacket.java
@@ -23,12 +23,12 @@ public final class UnknownPacket extends BedrockPacket implements BedrockPacketS
 
     @Override
     public void deserialize(ByteBuf buffer, BedrockPacketHelper helper, UnknownPacket packet) {
-        packet.payload = buffer.readBytes(buffer.readableBytes());
+        packet.payload = buffer.readRetainedSlice(buffer.readableBytes());
     }
 
     @Override
     public String toString() {
-        return "UNKNOWN - " + getPacketId() + " - Hex: " + (payload == null ? "null" : ByteBufUtil.hexDump(payload));
+        return "UNKNOWN - " + getPacketId() + " - Hex: " + (payload == null || payload.refCnt() == 0 ? "null" : ByteBufUtil.hexDump(payload));
     }
 
     @Override


### PR DESCRIPTION
This fixes unknown behavior when UnknownPacket is received.  Unhandled packets must be released correctly to prevent memory leaks.