### PR TITLE
Expose BedrockPacketHelper in the codec

### DIFF
--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/BedrockPacketCodec.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/BedrockPacketCodec.java
@@ -32,6 +32,7 @@ public final class BedrockPacketCodec {
     private final String minecraftVersion;
     private final BedrockPacketSerializer<BedrockPacket>[] serializers;
     private final Int2ObjectBiMap<Class<? extends BedrockPacket>> idBiMap;
+    @Getter
     private final BedrockPacketHelper helper;
     @Getter
     private final int raknetProtocolVersion;


### PR DESCRIPTION
Motive: the LevelEvent IDs need to be exposed for area effect cloud IDs. Our project previously implemented these IDs separately, but if using multiversion this is not a viable option.