### PR TITLE
fix: sound data fields in ClientboundUpdateSoundDataPacket are not optional

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v2168/serializer/ClientboundUpdateSoundDataSerializer_v2168.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v2168/serializer/ClientboundUpdateSoundDataSerializer_v2168.java
@@ -15,65 +15,93 @@ public class ClientboundUpdateSoundDataSerializer_v2168 extends ClientboundUpdat
     public void serialize(ByteBuf buffer, BedrockCodecHelper helper, ClientboundUpdateSoundDataPacket packet) {
         buffer.writeLongLE(packet.getServerSoundHandle());
 
-        helper.writeOptionalNull(buffer, packet.getStop(), (buf, d) -> {
-            VarInts.writeUnsignedInt(buffer, 0);
-        });
-        helper.writeOptionalNull(buffer, packet.getVolume(), (buf, d) -> {
-            VarInts.writeUnsignedInt(buffer, 0);
-            buf.writeFloatLE(d.getVolume());
-        });
-        helper.writeOptionalNull(buffer, packet.getPitch(), (buf, d) -> {
-            VarInts.writeUnsignedInt(buffer, 0);
-            buf.writeFloatLE(d.getPitch());
-        });
-        helper.writeOptionalNull(buffer, packet.getFade(), (buf, d) -> {
-            VarInts.writeUnsignedInt(buffer, 0);
-            buf.writeFloatLE(d.getTargetVolume());
-            buf.writeFloatLE(d.getDuration());
-        });
-        helper.writeOptionalNull(buffer, packet.getSeekTo(), (buf, d) -> {
-            VarInts.writeUnsignedInt(buffer, 0);
-            buf.writeFloatLE(d.getSeconds());
-        });
-        helper.writeOptionalNull(buffer, packet.getPause(), (buf, d) -> {
-            VarInts.writeUnsignedInt(buffer, 0);
-        });
-        helper.writeOptionalNull(buffer, packet.getResume(), (buf, d) -> {
-            VarInts.writeUnsignedInt(buffer, 0);
-        });
+        this.writeType(buffer, SoundDataType.STOP);
+
+        SetVolumeSoundData volume = packet.getVolume();
+        if (volume == null) {
+            this.writeType(buffer, SoundDataType.STOP);
+        } else {
+            this.writeType(buffer, SoundDataType.SET_VOLUME);
+            buffer.writeFloatLE(volume.getVolume());
+        }
+
+        SetPitchSoundData pitch = packet.getPitch();
+        if (pitch == null) {
+            this.writeType(buffer, SoundDataType.STOP);
+        } else {
+            this.writeType(buffer, SoundDataType.SET_PITCH);
+            buffer.writeFloatLE(pitch.getPitch());
+        }
+
+        FadeSoundData fade = packet.getFade();
+        if (fade == null) {
+            this.writeType(buffer, SoundDataType.STOP);
+        } else {
+            this.writeType(buffer, SoundDataType.FADE);
+            buffer.writeFloatLE(fade.getDuration());
+            buffer.writeFloatLE(fade.getTargetVolume());
+        }
+
+        SeekToSoundData seekTo = packet.getSeekTo();
+        if (seekTo == null) {
+            this.writeType(buffer, SoundDataType.STOP);
+        } else {
+            this.writeType(buffer, SoundDataType.SEEK_TO);
+            buffer.writeFloatLE(seekTo.getSeconds());
+        }
+
+        this.writeType(buffer, packet.getPause() == null ? SoundDataType.STOP : SoundDataType.PAUSE);
+        this.writeType(buffer, packet.getResume() == null ? SoundDataType.STOP : SoundDataType.RESUME);
     }
 
     @Override
     public void deserialize(ByteBuf buffer, BedrockCodecHelper helper, ClientboundUpdateSoundDataPacket packet) {
         packet.setServerSoundHandle(buffer.readLongLE());
 
-        packet.setStop(helper.readOptional(buffer, null, (buf, h) -> {
-            VarInts.readUnsignedInt(buf);
-            return new StopSoundData();
-        }));
-        packet.setVolume(helper.readOptional(buffer, null, (buf, h) -> {
-            VarInts.readUnsignedInt(buf);
-            return new SetVolumeSoundData(buf.readFloatLE());
-        }));
-        packet.setPitch(helper.readOptional(buffer, null, (buf, h) -> {
-            VarInts.readUnsignedInt(buf);
-            return new SetPitchSoundData(buf.readFloatLE());
-        }));
-        packet.setFade(helper.readOptional(buffer, null, (buf, h) -> {
-            VarInts.readUnsignedInt(buf);
-            return new FadeSoundData(buf.readFloatLE(), buf.readFloatLE());
-        }));
-        packet.setSeekTo(helper.readOptional(buffer, null, (buf, h) -> {
-            VarInts.readUnsignedInt(buf);
-            return new SeekToSoundData(buf.readFloatLE());
-        }));
-        packet.setPause(helper.readOptional(buffer, null, (buf, h) -> {
-            VarInts.readUnsignedInt(buf);
-            return new PauseSoundData();
-        }));
-        packet.setResume(helper.readOptional(buffer, null, (buf, h) -> {
-            VarInts.readUnsignedInt(buf);
-            return new ResumeSoundData();
-        }));
+        Object stop = this.readSoundData(buffer);
+        packet.setStop(stop instanceof StopSoundData ? (StopSoundData) stop : null);
+
+        Object volume = this.readSoundData(buffer);
+        packet.setVolume(volume instanceof SetVolumeSoundData ? (SetVolumeSoundData) volume : null);
+
+        Object pitch = this.readSoundData(buffer);
+        packet.setPitch(pitch instanceof SetPitchSoundData ? (SetPitchSoundData) pitch : null);
+
+        Object fade = this.readSoundData(buffer);
+        packet.setFade(fade instanceof FadeSoundData ? (FadeSoundData) fade : null);
+
+        Object seekTo = this.readSoundData(buffer);
+        packet.setSeekTo(seekTo instanceof SeekToSoundData ? (SeekToSoundData) seekTo : null);
+
+        Object pause = this.readSoundData(buffer);
+        packet.setPause(pause instanceof PauseSoundData ? (PauseSoundData) pause : null);
+
+        Object resume = this.readSoundData(buffer);
+        packet.setResume(resume instanceof ResumeSoundData ? (ResumeSoundData) resume : null);
+    }
+
+    protected void writeType(ByteBuf buffer, SoundDataType type) {
+        VarInts.writeUnsignedInt(buffer, type.ordinal());
+    }
+
+    protected Object readSoundData(ByteBuf buffer) {
+        switch (SoundDataType.from(VarInts.readUnsignedInt(buffer))) {
+            case SET_VOLUME:
+                return new SetVolumeSoundData(buffer.readFloatLE());
+            case SET_PITCH:
+                return new SetPitchSoundData(buffer.readFloatLE());
+            case FADE: {
+                float duration = buffer.readFloatLE();
+                return new FadeSoundData(buffer.readFloatLE(), duration);
+            }
+            case SEEK_TO:
+                return new SeekToSoundData(buffer.readFloatLE());
+            case PAUSE:
+                return new PauseSoundData();
+            case RESUME:
+                return new ResumeSoundData();
+            default:
+                return new StopSoundData();
+        }
     }
 }

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/sound/SoundDataType.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/sound/SoundDataType.java
@@ -1,0 +1,17 @@
+package org.cloudburstmc.protocol.bedrock.data.sound;
+
+public enum SoundDataType {
+    STOP,
+    SET_VOLUME,
+    SET_PITCH,
+    FADE,
+    SEEK_TO,
+    PAUSE,
+    RESUME;
+
+    private static final SoundDataType[] VALUES = SoundDataType.values();
+
+    public static SoundDataType from(int id) {
+        return VALUES[id];
+    }
+}


### PR DESCRIPTION
Source: https://github.com/Mojang/bedrock-protocol-docs/blob/main/json/ClientboundUpdateSoundDataPacketPayload.json, https://github.com/Mojang/bedrock-protocol-docs/blob/main/json/Fade.json