### PR TITLE
Fix v2168 packet serialization

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v2168/BedrockCodecHelper_v2168.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v2168/BedrockCodecHelper_v2168.java
@@ -12,6 +12,7 @@ import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.protocol.bedrock.codec.BedrockCodecHelper;
 import org.cloudburstmc.protocol.bedrock.codec.EntityDataTypeMap;
 import org.cloudburstmc.protocol.bedrock.codec.v975.BedrockCodecHelper_v975;
+import org.cloudburstmc.protocol.bedrock.data.PresenceConfiguration;
 import org.cloudburstmc.protocol.bedrock.data.Ability;
 import org.cloudburstmc.protocol.bedrock.data.GatheringsConfigurationJoinInfo;
 import org.cloudburstmc.protocol.bedrock.data.definitions.ItemDefinition;
@@ -1243,5 +1244,15 @@ public class BedrockCodecHelper_v2168 extends BedrockCodecHelper_v975 {
                 buffer.writeBoolean(false);
                 break;
         }
+    }
+
+    @Override
+    public void writePresenceConfiguration(ByteBuf buffer, PresenceConfiguration configuration) {
+        writeOptionalNull(buffer, configuration.getRichPresenceId(), this::writeString);
+    }
+
+    @Override
+    public PresenceConfiguration readPresenceConfiguration(ByteBuf buffer) {
+        return new PresenceConfiguration(null, null, readOptional(buffer, null, this::readString));
     }
 }

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v2168/serializer/PlayerUpdateEntityOverridesSerializer_v2168.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v2168/serializer/PlayerUpdateEntityOverridesSerializer_v2168.java
@@ -10,12 +10,26 @@ public class PlayerUpdateEntityOverridesSerializer_v2168 extends PlayerUpdateEnt
 
     public static final PlayerUpdateEntityOverridesSerializer_v2168 INSTANCE = new PlayerUpdateEntityOverridesSerializer_v2168();
 
+    private static final String[] TYPE_NAMES = {
+            "clearoverrides",
+            "removeoverride",
+            "setintoverride",
+            "setfloatoverride"
+    };
+
+    private static String typeName(int ordinal) {
+        if (ordinal < 0 || ordinal >= TYPE_NAMES.length) {
+            throw new IllegalStateException("Unknown entity override type: " + ordinal);
+        }
+        return TYPE_NAMES[ordinal];
+    }
+
     @Override
     public void serialize(ByteBuf buffer, BedrockCodecHelper helper, PlayerUpdateEntityOverridesPacket packet) {
         VarInts.writeLong(buffer, packet.getEntityUniqueId());
         VarInts.writeUnsignedInt(buffer, packet.getPropertyIndex());
         VarInts.writeUnsignedInt(buffer, packet.getUpdateType().ordinal());
-        buffer.writeByte(packet.getUpdateType().ordinal());
+        helper.writeString(buffer, typeName(packet.getUpdateType().ordinal()));
         if (packet.getUpdateType().equals(PlayerUpdateEntityOverridesPacket.UpdateType.SET_INT_OVERRIDE)) {
             buffer.writeIntLE(packet.getIntValue());
         } else if (packet.getUpdateType().equals(PlayerUpdateEntityOverridesPacket.UpdateType.SET_FLOAT_OVERRIDE)) {
@@ -29,8 +43,9 @@ public class PlayerUpdateEntityOverridesSerializer_v2168 extends PlayerUpdateEnt
         packet.setPropertyIndex(VarInts.readUnsignedInt(buffer));
 
         int type = VarInts.readUnsignedInt(buffer);
-        if (type != buffer.readUnsignedByte()) {
-            throw new IllegalStateException("type != legacy type");
+        String name = helper.readString(buffer);
+        if (!typeName(type).equals(name)) {
+            throw new IllegalStateException("type != type name (expected " + typeName(type) + ", got " + name + ")");
         }
 
         packet.setUpdateType(PlayerUpdateEntityOverridesPacket.UpdateType.values()[type]);


### PR DESCRIPTION
Two serialization fixes for the v2168 protocol:

 - PlayerUpdateEntityOverrides: the update type is now serialized as a string enum name (clearoverrides/removeoverride/setintoverride/setfloatoverride) instead of a single legacy byte, and validated against the type ordinal on deserialization.

 - PresenceConfiguration (used by StartGame / ServerPresenceInfo): only an optional rich presence id is serialized, instead of the two plain strings inherited from v975/v944, which caused an out-of-bounds read when servers sent a non-empty presence.
